### PR TITLE
chore: bump llama-cpp version to 0.1.108

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4747,9 +4747,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "llama-cpp-2"
-version = "0.1.107"
+version = "0.1.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf1e72044420c92eb66ec70521cdcfe872b1fe7e7383edd932424d32289105d"
+checksum = "a1881e45e7306b2d2fdb2b322619ce1dba7a4873a4d358f815976d7b4540952b"
 dependencies = [
  "enumflags2",
  "llama-cpp-sys-2",
@@ -7726,7 +7726,7 @@ checksum = "015e5fc3d023418b9db98ca9a7f3e90b305872eeafe5ca45c5c32b5eb335c1e8"
 dependencies = [
  "anyhow",
  "argon2",
- "base64 0.21.7",
+ "base64 0.22.1",
  "buffered-reader",
  "bzip2",
  "chrono",

--- a/crates/alith/examples/lazai_data_contribution_and_reward.rs
+++ b/crates/alith/examples/lazai_data_contribution_and_reward.rs
@@ -1,7 +1,6 @@
 use alith::data::crypto::{DecodeRsaPublicKey, Pkcs1v15Encrypt, RsaPublicKey, encrypt};
 use alith::data::storage::{DataStorage, PinataIPFS, UploadOptions};
 use alith::lazai::{Client, ProofRequest, U256};
-use reqwest;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -56,7 +56,7 @@ chrono.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
 # llamacpp
-llama-cpp-2 = { version = "0.1.107", optional = true }
+llama-cpp-2 = { version = "0.1.108", optional = true }
 
 [features]
 ort = ["dep:ort"]


### PR DESCRIPTION
re https://github.com/MetisProtocol/metis-sdk/issues/232