### PR TITLE
refactor: update terminology in AI inference documentation and metadata

### DIFF
--- a/website/src/content/lazai/_meta.js
+++ b/website/src/content/lazai/_meta.js
@@ -1,6 +1,6 @@
 export default {
   "index": "Overview",
   "data-provider": "Data Provider",
-  "ai-inference": "LazAI Computing API",
+  "ai-inference": "LazAI API",
   "building-on-lazai": "Building on LazAI"
 }; 

--- a/website/src/content/lazai/ai-inference.mdx
+++ b/website/src/content/lazai/ai-inference.mdx
@@ -1,5 +1,5 @@
 ---
-title: "LazAI Computing API"
+title: "LazAI API"
 description: "How to run AI inference on your contributed private data using LazAI."
 icon: "Cpu"
 ---
@@ -7,7 +7,7 @@ icon: "Cpu"
 import { Tabs } from "nextra/components";
 
 
-# LazAI Computing API
+# LazAI API
 
 One-step access to private data AI process, user can utilize privacy data on the LazAI for context engineering/inference/training/evaluation to build value-aligned agents. After contributing your private data and minting a DAT (Data Anchor Token), you can run AI inference on your data in a privacy-preserving way using LazAI. This workflow ensures your sensitive data remains secure and under your control, while still enabling powerful AI capabilities.
 


### PR DESCRIPTION
- Changed "Private Data Inference" to "LazAI Computing API" in both the metadata and the main documentation.
- Enhanced the documentation to clarify the AI inference process and added environment variable setup instructions for various APIs.