### PR TITLE
Suggestion : add Clone to WindowBufferMemory

### DIFF
--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -148,6 +148,7 @@ where
 }
 
 /// A memory structure that stores messages in a sliding window buffer.
+#[derive(Clone)]
 pub struct WindowBufferMemory {
     window_size: usize,
     messages: Vec<Message>,


### PR DESCRIPTION
If we want to store this memory in memory
for using within multiple contexts we will need it to be cloned
I encountered the need for this when building Haithe where I needed to store memory per user.
I recommend we make the WindowBufferMemory clonable