### PR TITLE
Fixed error in sdks>rust>Cargo.toml

### DIFF
--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["rlib", "cdylib"]
 
 [dependencies]
 alith.workspace = true


### PR DESCRIPTION
Crate Type Configuration: Changed from ["cdylib"] to ["rlib", "cdylib"] to support both:
    rlib: Standard Rust library format for use as a dependency in other Rust projects
    cdylib: C-compatible dynamic library for FFI scenarios