### PR TITLE
Add GitHub error identifier agent example using alith SDK and Groq API

### DIFF
--- a/sdks/node/examples/agent_github_errorIdentifier.ts
+++ b/sdks/node/examples/agent_github_errorIdentifier.ts
@@ -1,0 +1,17 @@
+import { Agent } from "alith";
+
+const githubDebugAgent = new Agent({
+  model: "llama-3.1-8b-instant",
+  apiKey: "<Your API Key>",
+  baseUrl: "https://api.groq.com/openai/v1",
+  preamble: "You are an expert in version control systems like Git and GitHub. Analyze error messages and provide accurate solutions step by step."
+});
+
+async function suggestFix(errorMessage) {
+  const suggestion = await githubDebugAgent.prompt(errorMessage);
+  console.log("Suggestion:", suggestion);
+}
+
+// Example usage
+const error = "error: Your local changes to the following files would be overwritten by merge: ";
+suggestFix(error);


### PR DESCRIPTION
This PR introduces a new example script **([agent_github_errorIdentifier.ts])** that demonstrates how to use the alith SDK with the Groq API to analyze Git/GitHub error messages and suggest step-by-step solutions.

- Uses the **llama-3.1-8b-instant** model with a version control expert preamble
- Accepts an error message and prints AI-generated troubleshooting advice
- Provides a practical reference for building developer support tools with alith and Groq